### PR TITLE
bugfix

### DIFF
--- a/knock_off/knock_off.py
+++ b/knock_off/knock_off.py
@@ -54,6 +54,9 @@ class KnockOff(BaseEstimator, TransformerMixin):
             args['kernel'] = self.kernel
             args['normalised'] = self.normalised
 
+        if self.normalise_input:
+            x = x / np.linalg.norm(x, ord=2, axis=0)
+
         assoc_func = self.get_association_measure()
 
         return assoc_func(x, y, **args)
@@ -101,10 +104,6 @@ class KnockOff(BaseEstimator, TransformerMixin):
             print("Starting screening")
             X1, y1 = X[set_one, :], y[set_one]
             X2, y2 = X[set_two, :], y[set_two]
-            
-            if self.normalise_input:
-                X1 = X1 / np.linalg.norm(X1, ord=2, axis=0)
-                X2 = X2 / np.linalg.norm(X2, ord=2, axis=0)
             
             self.A_d_hat_, self.screen_scores_ = screen(X1, y1, d, self.compute_assoc)
             screen_scores = None

--- a/knock_off/utils.py
+++ b/knock_off/utils.py
@@ -30,7 +30,6 @@ def build_knockoff(X, y, am, prescreened=None):
         X_wj = prescreened
 
     X_hat = get_equi_features(X)
-    #X_hat = X_hat / np.linalg.norm(X_hat, ord=2, axis=0)
     X_hat_wj = am(X_hat, y)[:, 0]
 
     return X_wj - X_hat_wj


### PR DESCRIPTION
this also normalizes X_hat when needed

beware: we must always write the feature vector first, then the outcome. This feels a bit unsafe. An alternative is to have build_knockoff take a flag to normalize X_hat as well